### PR TITLE
V1.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ VENV_WHEEL = $(VENV_SCRIPTS)/wheel$(EXE_EXT)
 VENV_TWINE = $(VENV_SCRIPTS)/twine$(EXE_EXT)
 VENV_PIP = $(VENV_PYTHON) -m pip
 CLEAN_ARGS = -dxe "*.egg-info" -e ".idea" -e ".vscode" -e "*.komodoproject" -e ".venv"
+PYTEST_ARGS = -W ignore --cov $(PROJECT_NAME) --junitxml result.junit.xml
 
 install: .venv
 	$(VENV_PIP) install -e .
@@ -64,7 +65,7 @@ lint: $(VENV_LINTER)
 	$(VENV_TYPECHKR) $(PROJECT_NAME)
 
 test: $(VENV_PYTEST)
-	$(VENV_PYTEST) --cov $(PROJECT_NAME) --junitxml result.junit.xml tests
+	$(VENV_PYTEST) $(PYTEST_ARGS) tests
 	$(VENV_PYTHON) -m coverage html
 
 docs: $(VENV_SPHINX)

--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ CLAC Layerizes Application Configuration
 
 ## Status
 
-Currently being refactored for use in the [pedestal](https://github.com/scruffystuffs/pedestal) framework 
+Released and ready for use.  More docs and examples may be added if needed. 

--- a/clac/__version__.py
+++ b/clac/__version__.py
@@ -32,8 +32,8 @@ incremented manually.
 """
 
 __major__: int = 1
-__minor__: int = 1
-__patch__: int = 1
+__minor__: int = 2
+__patch__: int = 0
 
 __version__ = (__major__, __minor__)
 __release__: str = f'{__major__}.{__minor__}.{__patch__}'

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with codecs.open(path.join(__here__, 'README.md'), encoding='utf-8') as f:
     __long_description__ = f.read()
 
 doc_requires = ['sphinx', 'sphinx_rtd_theme']
-test_requires = ['pytest', 'pytest-cov']
+test_requires = ['pytest>=3.6', 'pytest-cov']
 coverage_requires = ['coverage', 'codecov']
 lint_requires = ['pylint', 'mypy']
 pkg_requires = ['twine', 'wheel']

--- a/tests/test_clac.py
+++ b/tests/test_clac.py
@@ -2,7 +2,7 @@ import pathlib
 # import sys
 from typing import Iterable
 
-from pytest import raises, fixture, mark
+from pytest import raises, fixture
 
 # sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
 
@@ -196,15 +196,25 @@ def test_build_lri(clac_layers):
     }
 
 
-@mark.xfail
-def test_build_reverse_lri(clac_layers):
+def test_build_nri(clac_layers):
     simple_clac = CLAC(*clac_layers)
-    assert simple_clac.build_lri(True) == {
-        ('test_key', 'alpha'),
-        ('alpha_secret', 'alpha'),
-        ('unique', 'alpha'),
-        ('beta_secret', 'beta'),
-        ('gamma_secret', 'gamma'),
+    assert simple_clac.build_nri() == {
+        ('alpha', 'test_key'),
+        ('alpha', 'alpha_secret'),
+        ('alpha', 'unique'),
+        ('beta', 'beta_secret'),
+        ('gamma', 'gamma_secret'),
+    }
+
+
+def test_build_vri(clac_layers):
+    simple_clac = CLAC(*clac_layers)
+    assert simple_clac.build_vri() == {
+        ('alpha', 'test_key', 'test_value_alpha'),
+        ('alpha', 'alpha_secret', 'abcde'),
+        ('alpha', 'unique', '0123456789'),
+        ('beta', 'beta_secret', 'fghij'),
+        ('gamma', 'gamma_secret', 'gamma rules!'),
     }
 
 

--- a/tests/test_dict_layer.py
+++ b/tests/test_dict_layer.py
@@ -1,4 +1,4 @@
-from pytest import fixture, raises, mark
+from pytest import fixture, raises
 
 from clac import DictLayer, DictStructure, NoConfigKey
 
@@ -30,6 +30,14 @@ def fixture_dotted_dict_layer():
     )
 
 
+def test_init():
+    DictLayer('name')
+    with raises(TypeError):
+        DictLayer('name', 'not a mapping')
+    with raises(ValueError):
+        DictLayer('name', dot_strategy='not a DictStrucure')
+
+
 def test_blank_mutable():
     layer = DictLayer('name', mutable=True)
 
@@ -57,14 +65,6 @@ def test_mutable_split():
     assert layer.setdefault('new_key.subkey', unique) is unique
 
     assert layer['new_key'] == {'subkey': unique}
-
-
-@mark.xfail
-def test_blank_immutable_error():
-    with raises(ValueError):
-        layer = DictLayer('name')
-    with raises(ValueError):
-        layer = DictLayer('name', mutable=True, dot_strategy=None)
 
 
 def test_flat_len_dictlayer(flat_layer):

--- a/tests/test_env_layer.py
+++ b/tests/test_env_layer.py
@@ -19,3 +19,14 @@ def test_env_prefix():
     assert layer['some.secret.Key'] == '9876543210'
     assert layer.get('some.secret.key') == '9876543210'
     assert layer.get('this.does.not.exist') is None
+
+
+def test_env_names():
+    layer = EnvLayer('env', prefix='myprefix')
+
+    os.environ['MYPREFIX_SOME_SECRET_KEY'] = '9876543210'
+    os.environ['MYPREFIX_SOME_PUBLIC_KEY'] = 'abcd'
+    assert layer['some.secret.key'] == '9876543210'
+    assert layer.get('some.secret.key') == '9876543210'
+    assert layer.get('this.does.not.exist') is None
+    assert layer.names == {'some.secret.key'}


### PR DESCRIPTION
- Deprecated LRI in favor of NRI and VRI.
- EnvLayer reports only hits for the `names` property.